### PR TITLE
add the ability to search all partitions for a specific topic

### DIFF
--- a/src/client/kafka/messages/messages.tsx
+++ b/src/client/kafka/messages/messages.tsx
@@ -3,7 +3,7 @@ import { RouteComponentProps } from "react-router-dom";
 import { KafkaToolbar} from '../../common/toolbar';
 import { DataView} from '../../common/data_view';
 import { ErrorMsg} from '../../common/error_msg';
-import { SingleTopicInput, SearchBy} from './single_topic_input';
+import { SingleTopicInput, SearchBy, AllPartitions} from './single_topic_input';
 import { MultiTopicsInput} from './multi_topics_input';
 import Alert from '@material-ui/lab/Alert';
 import { GridReadyEvent, GridApi, ColumnApi, FilterChangedEvent } from 'ag-grid-community';
@@ -18,10 +18,18 @@ type State = {
     error: any;
     warning: string;
     customCols: {cols: {}};
+    partition?: string;
 }
 
 export class Messages extends React.Component<Props, State> {
-    state: State = { search: "", rows: [], customCols: {cols: {}}, error: "", warning: "" }
+    state: State = {
+        search: "",
+        rows: [],
+        customCols: {cols: {}},
+        error: "",
+        warning: "",
+        partition: this.props.match.params.partition,
+    }
     api: GridApi | null = null;
     columnApi: ColumnApi | null = null;
     url: Url;
@@ -108,6 +116,8 @@ export class Messages extends React.Component<Props, State> {
         ]
         if (this.props.match.params.topic === undefined) {
             cols.push({headerName: "Topic", field: "rowTopic"})
+        }
+        if (this.state.partition === AllPartitions) {
             cols.push({headerName: "Partition", field: "rowPartition"})
         }
         this.addCustomColumns(cols, this.state.customCols.cols, ``)
@@ -159,8 +169,8 @@ export class Messages extends React.Component<Props, State> {
         return `${month}/${day}/${year} ${hour}:${minute}:${second}.${millis}`
     }
 
-    onDataFetchStarted = () => {
-        this.setState({error: "", warning: ""})
+    onDataFetchStarted = (partition: string) => {
+        this.setState({error: "", warning: "", partition})
     }
 
     onDataFetched = (data: any) => {

--- a/src/client/kafka/messages/multi_topics_input.tsx
+++ b/src/client/kafka/messages/multi_topics_input.tsx
@@ -9,6 +9,7 @@ import Toolbar from '@material-ui/core/Toolbar';
 import MenuItem from '@material-ui/core/MenuItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import { GoButton } from './go_button';
+import { AllPartitions } from './single_topic_input';
 import { ErrorMsg} from '../../common/error_msg';
 import { Url } from '../../common/url';
 
@@ -19,7 +20,7 @@ interface Props {
     searchFrom?: any;
     limit?: any;
     onDataFetched: (data: any) => void;
-    onDataFetchStarted: () => void;
+    onDataFetchStarted: (partition: string) => void;
 }
 
 type State = {
@@ -76,7 +77,7 @@ export class MultiTopicsInput extends React.Component<Props, State> {
 
     fetchMessages = async () => {
         this.setState({ loadingMessages: true })
-        this.props.onDataFetchStarted()
+        this.props.onDataFetchStarted(AllPartitions)
         const topics = this.state.selectedTopics.join(`,`)
         const response = await fetch(
             `/api/messages-cross-topics/${topics}?limit=${this.state.limit}&search_from=${this.state.searchFrom}&search=${this.props.search}`,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -361,6 +361,10 @@ const getMessages = async (input: TopicQueryInput): Promise<MessagesResult> => {
 		await consumer.run({
 			autoCommit: false,
 			eachMessage: async ({ topic, partition, message }) => {
+				if (partition !== input.partition) {
+					console.log(`ignoreing message from partition ${partition} (offset ${message.offset}), expecting partition ${input.partition}`)
+					return
+				}
 				console.log(`---MESSAGE: ${message.offset}---`)
 				let schemaType : Type | undefined = undefined;
 				if (message.value === null) {


### PR DESCRIPTION
The single topic view now has the ability to select "all partitions" in the drop-down in addition to selecting a single partition.
When searching with limit, we interpret the limit as the limit for each partition.