### PR TITLE
upgrade react to 17.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2151,13 +2151,12 @@
       }
     },
     "react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha1-lNd23dCqo32j7aj8W2sYpMmjEU0=",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha1-0LXMUW0p6z7uOD91tihkz7aAADc=",
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
+        "object-assign": "^4.1.1"
       }
     },
     "react-base16-styling": {
@@ -2172,14 +2171,13 @@
       }
     },
     "react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha1-etg47Cmnd/s8dcOhkPZhz5Kri4k=",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha1-7P+2hF462Nv83EmPDQqTlzZQLCM=",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
+        "scheduler": "^0.20.2"
       }
     },
     "react-is": {
@@ -2363,9 +2361,9 @@
       "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
     },
     "scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha1-Tz4u0sGn1laB9MhU+oxaHMtA8ZY=",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha1-S67jlDbjSqk7SHS93L8P6Li1DpE=",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "long": "^4.0.0",
     "node-fetch": "^2.6.1",
     "qs": "^6.9.4",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "react-json-view": "^1.21.1",
     "react-router-dom": "^5.2.0",
     "uuid": "^8.1.0"


### PR DESCRIPTION
upgraded react to 17.0.2 to solve the console warning of deprecated shared array buffer.
Fixes #59 