### PR TITLE
cancel running queries when switching pages

### DIFF
--- a/src/client/common/loader.ts
+++ b/src/client/common/loader.ts
@@ -1,0 +1,40 @@
+export class Loader {
+    cancelToken: CancelToken | null = null;
+
+    public async Load(fn: (cancelToken: CancelToken) => Promise<void>) {
+        this.cancelToken = new CancelToken();
+        try {
+            await fn(this.cancelToken)
+        } catch (error) {
+            if (error.name === 'AbortError') {
+                return
+            }
+            throw(error)
+        }
+        finally {
+            this.cancelToken = null
+        }
+    }
+
+    public Abort() {
+        this.cancelToken?.abortController.abort();
+    }
+}
+
+export class CancelToken {
+    abortController: AbortController = new AbortController();
+
+    public get Signal(): AbortSignal {
+        return this.abortController.signal
+    }
+
+    public get Aborted(): boolean {
+        return this.abortController.signal.aborted
+    }
+
+    public async Fetch(url: string): Promise<any> {
+        const response = await fetch(url, { signal: this.Signal })
+        if (this.Aborted) return null
+        return await response.json()
+    }
+}

--- a/src/client/kafka/groups.tsx
+++ b/src/client/kafka/groups.tsx
@@ -6,6 +6,7 @@ import { KafkaToolbar} from '../common/toolbar';
 import { DataView} from '../common/data_view';
 import { ErrorMsg} from '../common/error_msg';
 import { Url } from "../common/url";
+import { CancelToken, Loader } from "../common/loader";
 
 type State = {
     loading: boolean;
@@ -22,6 +23,7 @@ class ViewMembersButton extends React.Component<CellProps, {}> {
 export class Groups extends React.Component<RouteComponentProps, State> {
     state: State = { loading: true, rows: [], error: "" }
     url: Url;
+    loader: Loader = new Loader()
 
     constructor(props: RouteComponentProps) {
         super(props);
@@ -29,8 +31,16 @@ export class Groups extends React.Component<RouteComponentProps, State> {
     }
 
     async componentDidMount() {
-        const response = await fetch(`/api/groups`)
-        const data = await response.json()
+        await this.loader.Load(this.fetchGroups)
+    }
+
+    componentWillUnmount() {
+        this.loader.Abort()
+    }
+
+    fetchGroups = async (cancelToken: CancelToken) => {
+        const data = await cancelToken.Fetch(`/api/groups`)
+        if (cancelToken.Aborted) return
         if (data.error) {
             this.setState({loading: false, error: data.error})
             return


### PR DESCRIPTION
If we are in the middle of a query and the user is navigating away, we previously did not cancel the ongoing query (or queries), and we were also trying to set the state on the unmounted react component triggering the error.

Added logic to allow cancelling existing queries (via the loader and cancel token combo) and applied it to all pages.

Fixes #60 