### PR TITLE
performance improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -143,7 +143,6 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
       "integrity": "sha1-BoWzxH6zAG/+0RfN1VFkth+AU48=",
-      "dev": true,
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -153,7 +152,6 @@
       "version": "3.4.34",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.34.tgz",
       "integrity": "sha1-FwpAIjptZmAG2TyhKK8r6x2bGQE=",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -188,7 +186,6 @@
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.11.tgz",
       "integrity": "sha1-3r48qm+OX82pa0e9VOL0DE7llUU=",
-      "dev": true,
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -200,7 +197,6 @@
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.19.tgz",
       "integrity": "sha1-AKz8FjLnKaysTxUw6eFvbdFQih0=",
-      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -227,14 +223,12 @@
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
-      "integrity": "sha1-k+Jb+e51/g/YC1lLxP6w6GIRG1o=",
-      "dev": true
+      "integrity": "sha1-k+Jb+e51/g/YC1lLxP6w6GIRG1o="
     },
     "@types/node": {
       "version": "12.20.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
-      "integrity": "sha1-HLYf0MhcuH5yjEMQe1/YK2m8nvg=",
-      "dev": true
+      "integrity": "sha1-HLYf0MhcuH5yjEMQe1/YK2m8nvg="
     },
     "@types/prop-types": {
       "version": "15.7.3",
@@ -244,14 +238,12 @@
     "@types/qs": {
       "version": "6.9.6",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.6.tgz",
-      "integrity": "sha1-35w8izGiR+wxXmmWVmvjFx30s7E=",
-      "dev": true
+      "integrity": "sha1-35w8izGiR+wxXmmWVmvjFx30s7E="
     },
     "@types/range-parser": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-      "integrity": "sha1-fuMwunyq+5gJC+zoal7kQRWQTCw=",
-      "dev": true
+      "integrity": "sha1-fuMwunyq+5gJC+zoal7kQRWQTCw="
     },
     "@types/react": {
       "version": "17.0.3",
@@ -317,7 +309,6 @@
       "version": "1.13.9",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.9.tgz",
       "integrity": "sha1-qs8oqFoF7imhH7fD6tk1rFbzPk4=",
-      "dev": true,
       "requires": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -1889,6 +1880,11 @@
         "ee-first": "1.1.1"
       }
     },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha1-dysK5qqlJcOZ5Imt+tkMQD6zwo8="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2434,6 +2430,17 @@
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
         "send": "0.17.1"
+      }
+    },
+    "server-timing": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/server-timing/-/server-timing-3.3.1.tgz",
+      "integrity": "sha1-4hxe8058LJHSCv31JZFUQpMHN4E=",
+      "requires": {
+        "@types/express": "^4.17.3",
+        "@types/node": "^12.12.30",
+        "minimist": "^1.2.5",
+        "on-headers": "^1.0.2"
       }
     },
     "setimmediate": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react-dom": "^17.0.2",
     "react-json-view": "^1.21.1",
     "react-router-dom": "^5.2.0",
+    "server-timing": "^3.3.1",
     "uuid": "^8.1.0"
   }
 }

--- a/src/client/kafka/messages/multi_topics_input.tsx
+++ b/src/client/kafka/messages/multi_topics_input.tsx
@@ -115,7 +115,7 @@ export class MultiTopicsInput extends React.Component<Props, State> {
             toTime={this.props.toTime}
             searchBy={this.props.searchBy}
             onDataFetched={this.props.onDataFetched}
-            onDataFetchStarted={() => { this.setState({loadingMessages: true}); this.props.onDataFetchStarted} }
+            onDataFetchStarted={() => { this.setState({loadingMessages: true}); this.props.onDataFetchStarted(AllPartitions)} }
             onDataFetchCompleted={() => this.setState({loadingMessages: false})}
             loadingMessages={this.state.loadingMessages}
             error={this.state.error ?? ""}

--- a/src/client/kafka/messages/single_topic_input.tsx
+++ b/src/client/kafka/messages/single_topic_input.tsx
@@ -134,7 +134,7 @@ export class SingleTopicInput extends React.Component<Props, State> {
                 toTime={this.props.toTime}
                 searchBy={this.props.searchBy}
                 onDataFetched={this.props.onDataFetched}
-                onDataFetchStarted={() => { this.setState({loadingMessages: true}); this.props.onDataFetchStarted} }
+                onDataFetchStarted={() => { this.setState({loadingMessages: true}); this.props.onDataFetchStarted(this.state.partition)} }
                 onDataFetchCompleted={() => this.setState({loadingMessages: false})}
                 loadingMessages={this.state.loadingMessages}
                 error={this.state.error ?? ""}


### PR DESCRIPTION
- Performance improvements:
   - Removed logging by default from server-side fetches to improve performance by x4 for the normal case
   - Using kafkajs per batch processing instead of per message processing, which gives us greater control to squeeze some more performance (we can discard complete batches for wrong partitions, and we can discard heartbeats as we don't intend to keep the consumer group alove)
   - Subscribing latest only instead of oldest only so for the scenario where the topic is stale we won't get unneeded messages from the time we subscribe until we seek to our desired offset
   - Added server timings for the message fetch request to help with profiling

- Transactional topic support: for transactional topics the offsets are not consecutive (apparently kafka transactional producers write control messages which are hidden), and the highest offset might not even exist. By moving to per batch processing it seems we're able to account for that as the batch's high offset from kafkajs will include the missing offset so we can check it and stop processing on time, avoiding a timeout which was the previous status quo

- Fixed a bug where we didn't show the partition column when selecting all partitions
- Fixed a bug where searching newest offsets with a limit bigger than the highest offset resulted in an error