### PR TITLE
Add lossy utf8 decoder

### DIFF
--- a/src/server/default.toml
+++ b/src/server/default.toml
@@ -11,13 +11,13 @@ urls = "localhost:9092"
 # key-decoders = "utf8"
 # value-decoders = "my_decoder,utf8"
 #
-# In this exaemple, for all topics that start with "test" (matched by a regular expression), auto-detection will use utf-8
+# In this example, for all topics that start with "test" (matched by a regular expression), auto-detection will use utf-8
 # for decoding the keys, and "my_decoder" (which is assumed to be a user written and installed decoder) will be first used to decode values,
 # and will fallback to utf-8 decoding if that fails.
 #
 # See the plugins example for how to write and install a custom decoder.
-key-decoders = "avro_confluent_schema_registry,utf8"
-value-decoders = "avro_confluent_schema_registry,utf8"
+key-decoders = "avro_confluent_schema_registry,utf8,utf8_lossy"
+value-decoders = "avro_confluent_schema_registry,utf8,utf8_lossy"
 
 [confluent-schema-registry]
 # The url used to connect to the confluent schema registry.

--- a/src/server/kafka/api.rs
+++ b/src/server/kafka/api.rs
@@ -262,10 +262,11 @@ pub fn get_group_members(group: &str) -> Result<Json<dto::GetGroupMembersResult>
 
 #[get("/api/topic/decoders")]
 pub fn get_decoders() -> Result<Json<dto::GetDecodersResult>, String> {
-    let decoders: Vec<dto::DecoderMetadata>;
+    let mut decoders: Vec<dto::DecoderMetadata>;
     unsafe {
         decoders = DECODERS.get_decoders_metadata();
     }
+    decoders.sort();
     Ok(Json(dto::GetDecodersResult{decoders: decoders}))
 }
 

--- a/src/server/kafka/decoders/decoders.rs
+++ b/src/server/kafka/decoders/decoders.rs
@@ -4,6 +4,7 @@ use crate::common::errors::map_error;
 use crate::kafka::decoders::avro::AvroConfluentDecoderBuilder;
 use crate::kafka::decoders::bytes::BytesDecoderBuilder;
 use crate::kafka::decoders::utf8::Utf8DecoderBuilder;
+use crate::kafka::decoders::utf8_lossy::Utf8LossyDecoderBuilder;
 use crate::config;
 use serverapi::{Decoder, DecoderBuilder};
 use std::env;
@@ -41,6 +42,7 @@ impl Decoders {
     pub async unsafe fn load_all_plugins(&mut self) -> Result<(), String> {
         self.install_decoder(Box::new(AvroConfluentDecoderBuilder::default())).await;
         self.install_decoder(Box::new(Utf8DecoderBuilder::default())).await;
+        self.install_decoder(Box::new(Utf8LossyDecoderBuilder::default())).await;
         self.install_decoder(Box::new(BytesDecoderBuilder::default())).await;
 
         let decoders_dir = "./decoders";

--- a/src/server/kafka/decoders/utf8_lossy.rs
+++ b/src/server/kafka/decoders/utf8_lossy.rs
@@ -1,0 +1,47 @@
+use async_trait::async_trait;
+use rdkafka::message::OwnedMessage;
+use rdkafka::message::Message;
+use serverapi::{Decoder, DecoderBuilder, Config, DecodingAttribute, DecodedContents};
+
+#[derive(Debug, Default)]
+pub struct Utf8LossyDecoderBuilder {}
+
+#[async_trait]
+impl DecoderBuilder for Utf8LossyDecoderBuilder {
+    async fn build(&self, _: Box<dyn Config + Send>) -> Box<dyn Decoder>{
+        Box::new(Utf8LossyDecoder{})
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Utf8LossyDecoder {
+}
+
+#[async_trait]
+impl Decoder for Utf8LossyDecoder {
+    fn id(&self) -> &'static str  {
+        "utf8_lossy"
+    }
+
+    fn display_name(&self) -> &'static str  {
+        "UTF-8 (Lossy)"
+    }
+
+    async fn decode(&self, message: &OwnedMessage, attribute: &DecodingAttribute) -> Result<DecodedContents, String> {
+        match attribute {
+            DecodingAttribute::Key => self.decode_payload(message.key()).await,
+            DecodingAttribute::Value => self.decode_payload(message.payload()).await,
+        }
+    }
+}
+
+impl Utf8LossyDecoder {
+    async fn decode_payload(&self, payload: Option<&[u8]>) -> Result<DecodedContents, String> {
+        match payload {
+            None => Ok(DecodedContents{json: None}),
+            Some(buffer) => {
+                Ok(DecodedContents{json: Some(String::from_utf8_lossy(buffer).to_string())})
+            }
+        }
+    }
+}

--- a/src/server/kafka/dto.rs
+++ b/src/server/kafka/dto.rs
@@ -147,10 +147,10 @@ pub enum SearchStyle {
     Regex,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Eq, Ord, PartialEq, PartialOrd)]
 pub struct DecoderMetadata {
-    pub id: String,
     pub display_name: String,
+    pub id: String,
 }
 
 #[derive(Serialize)]

--- a/src/server/main.rs
+++ b/src/server/main.rs
@@ -11,6 +11,7 @@ mod kafka {
     mod decoders {
         pub mod avro;
         pub mod utf8;
+        pub mod utf8_lossy;
         pub mod bytes;
         pub mod decoders;
     }


### PR DESCRIPTION
In addition to the utf8 decoder, added a lossy utf8 decoder, to allow viewing incomplete texts for messages which have some utf8 characters and some non-utf8 characters.